### PR TITLE
support send Error stack info to redis

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,6 +32,9 @@ function logstashRedis(config, layout) {
 }
 
 function sendLog(redis, key, logObject) {
+  if (logObject.message instanceof Error && logObject.message.stack) {
+    logObject.message = logObject.message.stack
+  }
   const logString = JSON.stringify(logObject);
   redis.rpush(key, logString, function (err, result) {
     if (err) {


### PR DESCRIPTION
When logging a Error info,  the result of JSON.stringify(err) is '{}', so I change the logObject message field when message is a Error Obejct.